### PR TITLE
Update `AboutUs` page & add skeletal PPP

### DIFF
--- a/docs/AboutUs.md
+++ b/docs/AboutUs.md
@@ -9,51 +9,53 @@ You can reach us at the email `seer[at]comp.nus.edu.sg`
 
 ## Project team
 
-### John Doe
+### Wen Li
 
-<img src="images/johndoe.png" width="200px">
+<img src="images/wendy0107.png" width="200px">
 
-[[homepage](http://www.comp.nus.edu.sg/~damithch)]
-[[github](https://github.com/johndoe)]
-[[portfolio](team/johndoe.md)]
-
-* Role: Project Advisor
-
-### Jane Doe
-
-<img src="images/johndoe.png" width="200px">
-
-[[github](http://github.com/johndoe)]
-[[portfolio](team/johndoe.md)]
+[[github](http://github.com/wendy0107)]
+[[portfolio](team/wendy0107.md)]
 
 * Role: Team Lead
+* Responsibilities: Leading the team
+
+### Shaun Tan
+
+<img src="images/evitanrelta.png" width="200px">
+
+[[github](https://github.com/EvitanRelta)]
+[[portfolio](team/evitanrelta.md)]
+
+* Role: Developer
+* Responsibilities: Dev Ops
+
+
+### Shao Hong
+
+<img src="images/sheemo.png" width="200px">
+
+[[github](http://github.com/Sheemo)]
+[[portfolio](team/sheemo.md)]
+
+* Role: Developer
 * Responsibilities: UI
 
-### Johnny Doe
+### Benny
 
-<img src="images/johndoe.png" width="200px">
+<img src="images/bentimate.png" width="200px">
 
-[[github](http://github.com/johndoe)] [[portfolio](team/johndoe.md)]
+[[github](http://github.com/Bentimate)]
+[[portfolio](team/bentimate.md)]
+
+* Role: Developer
+* Responsibilities: Coding
+
+### Wei Chun
+
+<img src="images/alextang809.png" width="200px">
+
+[[github](http://github.com/alextang809)]
+[[portfolio](team/alextang809.md)]
 
 * Role: Developer
 * Responsibilities: Data
-
-### Jean Doe
-
-<img src="images/johndoe.png" width="200px">
-
-[[github](http://github.com/johndoe)]
-[[portfolio](team/johndoe.md)]
-
-* Role: Developer
-* Responsibilities: Dev Ops + Threading
-
-### James Doe
-
-<img src="images/johndoe.png" width="200px">
-
-[[github](http://github.com/johndoe)]
-[[portfolio](team/johndoe.md)]
-
-* Role: Developer
-* Responsibilities: UI

--- a/docs/team/alextang809.md
+++ b/docs/team/alextang809.md
@@ -9,7 +9,7 @@ AddressBook - Level 3 is a desktop address book application used for teaching So
 
 Given below are my contributions to the project.
 
-* **Code contributed**: [RepoSense link]()
+* **Code contributed**: [RepoSense link](https://nus-cs2103-ay2223s2.github.io/tp-dashboard/?search=alextang809&breakdown=true)
 
 * **Enhancements implemented**:
   * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())

--- a/docs/team/alextang809.md
+++ b/docs/team/alextang809.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: John Doe's Project Portfolio Page
+---
+
+### Project: AddressBook Level 3
+
+AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+
+Given below are my contributions to the project.
+
+* **Code contributed**: [RepoSense link]()
+
+* **Enhancements implemented**:
+  * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())
+  * Wrote additional tests for existing features to increase coverage from 88% to 92% (Pull requests [\#36](), [\#38]())
+
+* **Documentation**:
+  * User Guide:
+    * Added documentation for the features `delete` and `find` [\#72]()
+    * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
+  * Developer Guide:
+    * Added implementation details of the `delete` feature.
+
+* **Community**:
+  * PRs reviewed (with non-trivial review comments): [\#12](), [\#32](), [\#19](), [\#42]()
+  * Contributed to forum discussions (examples: [1](), [2](), [3](), [4]())
+  * Reported bugs and suggestions for other teams in the class (examples: [1](), [2](), [3]())
+  * Some parts of the history feature I added was adopted by several other class mates ([1](), [2]())
+
+* **Contributions beyond the project team**:
+  * Responded to forum posts ([\#42]())
+  * Reported bugs found in other team's products ([\#42]())

--- a/docs/team/bentimate.md
+++ b/docs/team/bentimate.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: John Doe's Project Portfolio Page
+---
+
+### Project: AddressBook Level 3
+
+AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+
+Given below are my contributions to the project.
+
+* **Code contributed**: [RepoSense link]()
+
+* **Enhancements implemented**:
+  * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())
+  * Wrote additional tests for existing features to increase coverage from 88% to 92% (Pull requests [\#36](), [\#38]())
+
+* **Documentation**:
+  * User Guide:
+    * Added documentation for the features `delete` and `find` [\#72]()
+    * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
+  * Developer Guide:
+    * Added implementation details of the `delete` feature.
+
+* **Community**:
+  * PRs reviewed (with non-trivial review comments): [\#12](), [\#32](), [\#19](), [\#42]()
+  * Contributed to forum discussions (examples: [1](), [2](), [3](), [4]())
+  * Reported bugs and suggestions for other teams in the class (examples: [1](), [2](), [3]())
+  * Some parts of the history feature I added was adopted by several other class mates ([1](), [2]())
+
+* **Contributions beyond the project team**:
+  * Responded to forum posts ([\#42]())
+  * Reported bugs found in other team's products ([\#42]())

--- a/docs/team/bentimate.md
+++ b/docs/team/bentimate.md
@@ -9,7 +9,7 @@ AddressBook - Level 3 is a desktop address book application used for teaching So
 
 Given below are my contributions to the project.
 
-* **Code contributed**: [RepoSense link]()
+* **Code contributed**: [RepoSense link](https://nus-cs2103-ay2223s2.github.io/tp-dashboard/?search=bentimate&breakdown=true)
 
 * **Enhancements implemented**:
   * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())

--- a/docs/team/evitanrelta.md
+++ b/docs/team/evitanrelta.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: John Doe's Project Portfolio Page
+---
+
+### Project: AddressBook Level 3
+
+AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+
+Given below are my contributions to the project.
+
+* **Code contributed**: [RepoSense link]()
+
+* **Enhancements implemented**:
+  * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())
+  * Wrote additional tests for existing features to increase coverage from 88% to 92% (Pull requests [\#36](), [\#38]())
+
+* **Documentation**:
+  * User Guide:
+    * Added documentation for the features `delete` and `find` [\#72]()
+    * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
+  * Developer Guide:
+    * Added implementation details of the `delete` feature.
+
+* **Community**:
+  * PRs reviewed (with non-trivial review comments): [\#12](), [\#32](), [\#19](), [\#42]()
+  * Contributed to forum discussions (examples: [1](), [2](), [3](), [4]())
+  * Reported bugs and suggestions for other teams in the class (examples: [1](), [2](), [3]())
+  * Some parts of the history feature I added was adopted by several other class mates ([1](), [2]())
+
+* **Contributions beyond the project team**:
+  * Responded to forum posts ([\#42]())
+  * Reported bugs found in other team's products ([\#42]())

--- a/docs/team/evitanrelta.md
+++ b/docs/team/evitanrelta.md
@@ -9,7 +9,7 @@ AddressBook - Level 3 is a desktop address book application used for teaching So
 
 Given below are my contributions to the project.
 
-* **Code contributed**: [RepoSense link]()
+* **Code contributed**: [RepoSense link](https://nus-cs2103-ay2223s2.github.io/tp-dashboard/?search=evitanrelta&breakdown=true)
 
 * **Enhancements implemented**:
   * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())

--- a/docs/team/sheemo.md
+++ b/docs/team/sheemo.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: John Doe's Project Portfolio Page
+---
+
+### Project: AddressBook Level 3
+
+AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+
+Given below are my contributions to the project.
+
+* **Code contributed**: [RepoSense link]()
+
+* **Enhancements implemented**:
+  * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())
+  * Wrote additional tests for existing features to increase coverage from 88% to 92% (Pull requests [\#36](), [\#38]())
+
+* **Documentation**:
+  * User Guide:
+    * Added documentation for the features `delete` and `find` [\#72]()
+    * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
+  * Developer Guide:
+    * Added implementation details of the `delete` feature.
+
+* **Community**:
+  * PRs reviewed (with non-trivial review comments): [\#12](), [\#32](), [\#19](), [\#42]()
+  * Contributed to forum discussions (examples: [1](), [2](), [3](), [4]())
+  * Reported bugs and suggestions for other teams in the class (examples: [1](), [2](), [3]())
+  * Some parts of the history feature I added was adopted by several other class mates ([1](), [2]())
+
+* **Contributions beyond the project team**:
+  * Responded to forum posts ([\#42]())
+  * Reported bugs found in other team's products ([\#42]())

--- a/docs/team/sheemo.md
+++ b/docs/team/sheemo.md
@@ -9,7 +9,7 @@ AddressBook - Level 3 is a desktop address book application used for teaching So
 
 Given below are my contributions to the project.
 
-* **Code contributed**: [RepoSense link]()
+* **Code contributed**: [RepoSense link](https://nus-cs2103-ay2223s2.github.io/tp-dashboard/?search=sheemo&breakdown=true)
 
 * **Enhancements implemented**:
   * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())

--- a/docs/team/wendy0107.md
+++ b/docs/team/wendy0107.md
@@ -9,7 +9,7 @@ AddressBook - Level 3 is a desktop address book application used for teaching So
 
 Given below are my contributions to the project.
 
-* **Code contributed**: [RepoSense link]()
+* **Code contributed**: [RepoSense link](https://nus-cs2103-ay2223s2.github.io/tp-dashboard/?search=wendy0107&breakdown=true)
 
 * **Enhancements implemented**:
   * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())

--- a/docs/team/wendy0107.md
+++ b/docs/team/wendy0107.md
@@ -1,0 +1,33 @@
+---
+layout: page
+title: John Doe's Project Portfolio Page
+---
+
+### Project: AddressBook Level 3
+
+AddressBook - Level 3 is a desktop address book application used for teaching Software Engineering principles. The user interacts with it using a CLI, and it has a GUI created with JavaFX. It is written in Java, and has about 10 kLoC.
+
+Given below are my contributions to the project.
+
+* **Code contributed**: [RepoSense link]()
+
+* **Enhancements implemented**:
+  * Updated the GUI color scheme (Pull requests [\#33](), [\#34]())
+  * Wrote additional tests for existing features to increase coverage from 88% to 92% (Pull requests [\#36](), [\#38]())
+
+* **Documentation**:
+  * User Guide:
+    * Added documentation for the features `delete` and `find` [\#72]()
+    * Did cosmetic tweaks to existing documentation of features `clear`, `exit`: [\#74]()
+  * Developer Guide:
+    * Added implementation details of the `delete` feature.
+
+* **Community**:
+  * PRs reviewed (with non-trivial review comments): [\#12](), [\#32](), [\#19](), [\#42]()
+  * Contributed to forum discussions (examples: [1](), [2](), [3](), [4]())
+  * Reported bugs and suggestions for other teams in the class (examples: [1](), [2](), [3]())
+  * Some parts of the history feature I added was adopted by several other class mates ([1](), [2]())
+
+* **Contributions beyond the project team**:
+  * Responded to forum posts ([\#42]())
+  * Reported bugs found in other team's products ([\#42]())


### PR DESCRIPTION
I've update the RepoSense links in each [PPP], but each member's skeletal PPP still needs to be populated with their own contributions.

Closes #20

[PPP]: https://nus-cs2103-ay2223s2.github.io/website/schedule/week7/project.html#4-add-a-skeletal-ppp