### PR TITLE
Fix table of contents in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -2,6 +2,9 @@
 layout: page
 title: User Guide
 ---
+## Table of Contents
+{:.no_toc}
+
 * Table of Contents
 {:toc}
 


### PR DESCRIPTION
The table of contents (TOC) in the UG is missing it's header as shown:

![image](https://user-images.githubusercontent.com/35413456/227772949-26de3590-e224-496a-a22d-6ff60c3fa169.png)

which breaks the `↑ Back to top` links as they rely on TOC header to be there

![image](https://user-images.githubusercontent.com/35413456/227772893-c72df0df-23b1-4a3b-bf39-57ffc995fabe.png)
