### PR TITLE
Revert unique Telegram/phone/case-insensitive-name feature

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -92,7 +92,7 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same name, number, or telegram handle.
+     * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.
      */
     public boolean isSamePerson(Person otherPerson) {
@@ -100,19 +100,8 @@ public class Person {
             return true;
         }
 
-        boolean isSameName = otherPerson.getName().fullName.equalsIgnoreCase(getName().fullName);
-
-        Phone thisNumber = this.getOptionalPhone().orElse(null);
-        Phone otherNumber = otherPerson.getOptionalPhone().orElse(null);
-        boolean isSameNumber = thisNumber == otherNumber
-                && thisNumber != null && otherNumber != null;
-
-        Telegram thisTele = this.getOptionalTelegram().orElse(null);
-        Telegram otherTele = otherPerson.getOptionalTelegram().orElse(null);
-        boolean isSameTele = thisTele == otherTele
-                && thisTele != null && otherTele != null;
-
-        return otherPerson != null && (isSameName || isSameNumber || isSameTele);
+        return otherPerson != null
+                && otherPerson.getName().equals(getName());
     }
 
     /**


### PR DESCRIPTION
This reverts commit 8e1a476738d7bf943576d72a7a387101f819a1f8.

@wendy0107 have u added in our UG that duplicate case-insensitive-names/telegram/phone isn't checked?

and added how we plan to prevent those duplicates in future in DG's planned Enhancement section?

![image](https://user-images.githubusercontent.com/35413456/230338670-512199d5-31a7-442c-a71b-a09925578d27.png)
