### PR TITLE
Move `CommandHistory` from `LogicManager` to `ModelManager`

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -49,7 +49,7 @@ public class LogicManager implements Logic {
 
         CommandResult commandResult;
         Command command = addressBookParser.parseCommand(commandText);
-        commandResult = command.execute(model, commandHistory);
+        commandResult = command.execute(model);
         try {
             storage.saveAddressBook(model.getAddressBook());
         } catch (IOException ioe) {

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -9,7 +9,6 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AutocompleteEngine;
 import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.CommandHistory;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
@@ -29,7 +28,6 @@ public class LogicManager implements Logic {
     private final Model model;
     private final Storage storage;
     private final AddressBookParser addressBookParser;
-    private final CommandHistory commandHistory;
     private final AutocompleteEngine autocompleteEngine;
 
     /**
@@ -39,7 +37,6 @@ public class LogicManager implements Logic {
         this.model = model;
         this.storage = storage;
         addressBookParser = new AddressBookParser();
-        commandHistory = new CommandHistory();
         autocompleteEngine = new AutocompleteEngine(model);
     }
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -69,7 +69,7 @@ public class AddCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) throws CommandException {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
         if (model.hasPerson(toAdd)) {

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -77,8 +77,7 @@ public class AddCommand extends Command {
         }
 
         model.addPerson(toAdd);
-        model.commitAddressBook();
-        commandHistory.updateAsModifyingHistory(COMMAND_WORD);
+        model.commitAddressBook(COMMAND_WORD);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -21,8 +21,7 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
-        model.commitAddressBook();
-        commandHistory.updateAsModifyingHistory(COMMAND_WORD);
+        model.commitAddressBook(COMMAND_WORD);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -18,7 +18,7 @@ public class ClearCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
         model.commitAddressBook();

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -15,5 +15,5 @@ public abstract class Command {
      * @return feedback message of the operation result for display
      * @throws CommandException If an error occurs during command execution.
      */
-    public abstract CommandResult execute(Model model, CommandHistory commandHistory) throws CommandException;
+    public abstract CommandResult execute(Model model) throws CommandException;
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -63,9 +63,8 @@ public class DeleteCommand extends Command {
         String deletedPersons = String.join(", ", personsToDelete.stream()
                 .map(Person::toString)
                 .toArray(String[]::new));
-        model.commitAddressBook();
+        model.commitAddressBook(COMMAND_WORD);
         model.setDefaultShowPerson();
-        commandHistory.updateAsModifyingHistory(COMMAND_WORD);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, deletedPersons));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -42,7 +42,7 @@ public class DeleteCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) throws CommandException {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -106,8 +106,7 @@ public class EditCommand extends Command {
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         model.updateShowPerson(new FullNamePredicate(editedPerson.getName().fullName));
-        model.commitAddressBook();
-        commandHistory.updateAsModifyingHistory(COMMAND_WORD);
+        model.commitAddressBook(COMMAND_WORD);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -88,7 +88,7 @@ public class EditCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) throws CommandException {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -16,7 +16,7 @@ public class ExitCommand extends Command {
     public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) {
+    public CommandResult execute(Model model) {
         return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, null);
     }
 

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -54,7 +54,7 @@ public class FilterCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -54,7 +54,7 @@ public class FindCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -20,7 +20,7 @@ public class HelpCommand extends Command {
 
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) {
+    public CommandResult execute(Model model) {
         return new CommandResult(SHOWING_HELP_MESSAGE, true, false, null);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -19,7 +19,7 @@ public class ListCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Listed all persons";
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -26,7 +26,7 @@ public class RedoCommand extends Command {
     private String commandToRedo;
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) throws CommandException {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         if (!model.checkRedoable()) {
             throw new CommandException(MESSAGE_FAILURE);

--- a/src/main/java/seedu/address/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RedoCommand.java
@@ -33,7 +33,7 @@ public class RedoCommand extends Command {
         } else {
             model.redoAddressBook();
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            commandToRedo = commandHistory.getLatestModifyingCommand();
+            commandToRedo = model.getLatestModifyingCommand();
             String message = String.format(MESSAGE_SUCCESS, commandToRedo);
             return new CommandResult(message);
         }

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -56,7 +56,7 @@ public class RemarkCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) throws CommandException {
+    public CommandResult execute(Model model) throws CommandException {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -82,8 +82,7 @@ public class RemarkCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        model.commitAddressBook();
-        commandHistory.updateAsModifyingHistory(COMMAND_WORD);
+        model.commitAddressBook(COMMAND_WORD);
         return new CommandResult(generateSuccessMessage(editedPerson));
     }
 

--- a/src/main/java/seedu/address/logic/commands/ShowRemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowRemarkCommand.java
@@ -48,7 +48,7 @@ public class ShowRemarkCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) throws CommandException {
+    public CommandResult execute(Model model) throws CommandException {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -34,7 +34,7 @@ public class UndoCommand extends Command {
         } else {
             model.undoAddressBook();
             model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-            commandToUndo = commandHistory.getLastExecutedCommand();
+            commandToUndo = model.getLastExecutedCommand();
             String message = String.format(MESSAGE_SUCCESS, commandToUndo);
             return new CommandResult(message);
         }

--- a/src/main/java/seedu/address/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UndoCommand.java
@@ -26,7 +26,7 @@ public class UndoCommand extends Command {
     private String commandToUndo;
 
     @Override
-    public CommandResult execute(Model model, CommandHistory commandHistory) throws CommandException {
+    public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
         if (!model.checkUndoable()) {

--- a/src/main/java/seedu/address/model/CommandHistory.java
+++ b/src/main/java/seedu/address/model/CommandHistory.java
@@ -1,4 +1,4 @@
-package seedu.address.logic.commands;
+package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -135,9 +135,11 @@ public interface Model {
     void redoAddressBook();
 
     /**
-     * Saves the current version of AddressBook to versionStateHistory.
+     * Saves the current version of AddressBook and the last executed command.
+     *
+     * @param lastExecutedCommand The name of the command to be updated to the command history.
      */
-    void commitAddressBook();
+    void commitAddressBook(String lastExecutedCommand);
 
     /**
      * Returns a list of all existing tag values (without duplicates) contained

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -142,6 +142,18 @@ public interface Model {
     void commitAddressBook(String lastExecutedCommand);
 
     /**
+     * Returns the command name of the last executed command that modified AddressBook.
+     * @return Command name as a string.
+     */
+    String getLastExecutedCommand();
+
+    /**
+     * Returns the command name of the last command undone.
+     * @return Command name as a String.
+     */
+    String getLatestModifyingCommand();
+
+    /**
      * Returns a list of all existing tag values (without duplicates) contained
      * in the person list.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -146,8 +146,9 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void commitAddressBook() {
+    public void commitAddressBook(String lastExecutedCommand) {
         versionedAddressBook.commit();
+        commandHistory.updateAsModifyingHistory(lastExecutedCommand);
     }
 
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -151,6 +151,15 @@ public class ModelManager implements Model {
         commandHistory.updateAsModifyingHistory(lastExecutedCommand);
     }
 
+    @Override
+    public String getLastExecutedCommand() {
+        return commandHistory.getLastExecutedCommand();
+    }
+
+    @Override
+    public String getLatestModifyingCommand() {
+        return commandHistory.getLatestModifyingCommand();
+    }
 
 
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -26,6 +26,7 @@ public class ModelManager implements Model {
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Person> targetPerson;
     private final VersionedAddressBook versionedAddressBook;
+    private final CommandHistory commandHistory;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -35,6 +36,7 @@ public class ModelManager implements Model {
 
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
+        commandHistory = new CommandHistory();
         versionedAddressBook = new VersionedAddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         targetPerson = new FilteredList<Person>(versionedAddressBook.getPersonList());

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -193,7 +193,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void commitAddressBook() {
+        public void commitAddressBook(String lastExecutedCommand) {
             throw new AssertionError("This method should not be called");
         }
 
@@ -209,6 +209,16 @@ public class AddCommandTest {
 
         @Override
         public void setDefaultShowPerson() {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public String getLastExecutedCommand() {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public String getLatestModifyingCommand() {
             throw new AssertionError("This method should not be called");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -36,7 +36,7 @@ public class AddCommandTest {
         ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
         Person validPerson = new PersonBuilder().build();
 
-        CommandResult commandResult = new AddCommand(validPerson).execute(modelStub, new CommandHistory());
+        CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
 
         assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validPerson), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
@@ -49,7 +49,7 @@ public class AddCommandTest {
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () ->
-                addCommand.execute(modelStub, new CommandHistory()));
+                addCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -94,7 +94,7 @@ public class CommandTestUtil {
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
             Model expectedModel) {
         try {
-            CommandResult result = command.execute(actualModel, new CommandHistory());
+            CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
@@ -124,7 +124,7 @@ public class CommandTestUtil {
         AddressBook expectedAddressBook = new AddressBook(actualModel.getAddressBook());
         List<Person> expectedFilteredList = new ArrayList<>(actualModel.getFilteredPersonList());
 
-        assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel, new CommandHistory()));
+        assertThrows(CommandException.class, expectedMessage, () -> command.execute(actualModel));
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }


### PR DESCRIPTION
So that `Command` won't have to take in `CommandHistory` in `Command::execute`

![image](https://user-images.githubusercontent.com/35413456/230374236-0b1589dc-5d25-4319-9b28-15a7a570ce7c.png)
