### PR TITLE
Refactor command usage msg

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -27,15 +27,15 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
     public static final ArrayList<Prefix> ARGUMENT_PREFIXES = new ArrayList<>(List.of(
-            PREFIX_NAME,
-            PREFIX_PHONE.asOptional(),
-            PREFIX_EMAIL.asOptional(),
-            PREFIX_ADDRESS.asOptional(),
-            PREFIX_EDUCATION.asOptional(),
-            PREFIX_TELEGRAM.asOptional(),
-            PREFIX_REMARK.asOptional(),
-            PREFIX_TAG.asOptional().asRepeatable(),
-            PREFIX_MODULE.asOptional().asRepeatable()
+            PREFIX_NAME.setExamples("John Doe"),
+            PREFIX_PHONE.asOptional().setExamples("98765432"),
+            PREFIX_EMAIL.asOptional().setExamples("johnd@example.com"),
+            PREFIX_ADDRESS.asOptional().setExamples("311, Clementi Ave 2, #02-25"),
+            PREFIX_EDUCATION.asOptional().setExamples("Year 1"),
+            PREFIX_TELEGRAM.asOptional().setExamples("@johndtele"),
+            PREFIX_REMARK.asOptional().setExamples("Have submitted tutorial worksheet for Week 10"),
+            PREFIX_TAG.asOptional().asRepeatable().setExamples("Tut1", "hasSubmitted"),
+            PREFIX_MODULE.asOptional().asRepeatable().setExamples("CS2103T")
     ));
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
@@ -43,17 +43,7 @@ public class AddCommand extends Command {
             + ARGUMENT_PREFIXES.stream()
                     .map(Prefix::toString)
                     .collect(Collectors.joining(" "))
-            + "\nExample: " + COMMAND_WORD + " "
-            + PREFIX_NAME.getPrefix() + "John Doe "
-            + PREFIX_PHONE.getPrefix() + "98765432 "
-            + PREFIX_EMAIL.getPrefix() + "johnd@example.com "
-            + PREFIX_ADDRESS.getPrefix() + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_EDUCATION.getPrefix() + "P6 "
-            + PREFIX_REMARK.getPrefix() + "Needs help with algebra "
-            + PREFIX_TAG.getPrefix() + "friends "
-            + PREFIX_TAG.getPrefix() + "owesMoney "
-            + PREFIX_MODULE.getPrefix() + "CS2103T "
-            + PREFIX_TELEGRAM.getPrefix() + "@johndtele";
+            + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -13,7 +13,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.Prefix;
@@ -38,11 +37,8 @@ public class AddCommand extends Command {
             PREFIX_MODULE.asOptional().asRepeatable().setExamples("CS2103T")
     ));
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
-            + "Parameters: "
-            + ARGUMENT_PREFIXES.stream()
-                    .map(Prefix::toString)
-                    .collect(Collectors.joining(" "))
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book."
+            + "\n" + getParameterUsage(ARGUMENT_PREFIXES)
             + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -22,6 +22,12 @@ public abstract class Command {
      */
     public abstract CommandResult execute(Model model) throws CommandException;
 
+    protected static String getParameterUsage(List<Prefix> argumentPrefixes) {
+        return "Parameters:\n" + argumentPrefixes.stream()
+                .map(Prefix::toString)
+                .collect(Collectors.joining(" "));
+    }
+
     protected static String getExampleUsage(String commandWord, List<Prefix> argumentPrefixes) {
         return "Example:\n" + commandWord + " " + argumentPrefixes.stream()
                 .map(Prefix::toExampleString)

--- a/src/main/java/seedu/address/logic/commands/Command.java
+++ b/src/main/java/seedu/address/logic/commands/Command.java
@@ -1,6 +1,11 @@
 package seedu.address.logic.commands;
 
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.model.Model;
 
 /**
@@ -16,4 +21,11 @@ public abstract class Command {
      * @throws CommandException If an error occurs during command execution.
      */
     public abstract CommandResult execute(Model model) throws CommandException;
+
+    protected static String getExampleUsage(String commandWord, List<Prefix> argumentPrefixes) {
+        return "Example:\n" + commandWord + " " + argumentPrefixes.stream()
+                .map(Prefix::toExampleString)
+                .filter(Predicate.not(String::isEmpty))
+                .collect(Collectors.joining(" "));
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.INDEX_PLACEHOLDER;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -26,11 +25,8 @@ public class DeleteCommand extends Command {
     ));
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Delete the persons identified by the index numbers used in the displayed person list.\n"
-            + "Parameters: "
-            + ARGUMENT_PREFIXES.stream()
-                    .map(Prefix::toString)
-                    .collect(Collectors.joining(" "))
+            + ": Delete the persons identified by the index numbers used in the displayed person list."
+            + "\n" + getParameterUsage(ARGUMENT_PREFIXES)
             + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Persons: %1$s";

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -21,8 +21,8 @@ public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
     public static final ArrayList<Prefix> ARGUMENT_PREFIXES = new ArrayList<>(List.of(
-            INDEX_PLACEHOLDER,
-            INDEX_PLACEHOLDER.asOptional().asRepeatable()
+            INDEX_PLACEHOLDER.setExamples("1"),
+            INDEX_PLACEHOLDER.asOptional().asRepeatable().setExamples("3", "5")
     ));
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -31,7 +31,7 @@ public class DeleteCommand extends Command {
             + ARGUMENT_PREFIXES.stream()
                     .map(Prefix::toString)
                     .collect(Collectors.joining(" "))
-            + "Example: " + COMMAND_WORD + " 1 2 3";
+            + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Persons: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -58,11 +57,8 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
-            + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: "
-            + ARGUMENT_PREFIXES.stream()
-                    .map(Prefix::toString)
-                    .collect(Collectors.joining(" "))
+            + "Existing values will be overwritten by the input values."
+            + "\n" + getParameterUsage(ARGUMENT_PREFIXES)
             + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -45,13 +45,13 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
     public static final ArrayList<Prefix> ARGUMENT_PREFIXES = new ArrayList<>(List.of(
-            INDEX_PLACEHOLDER,
+            INDEX_PLACEHOLDER.setExamples("1"),
             PREFIX_NAME.asOptional(),
-            PREFIX_PHONE.asOptional(),
-            PREFIX_EMAIL.asOptional(),
+            PREFIX_PHONE.asOptional().setExamples("91234567"),
+            PREFIX_EMAIL.asOptional().setExamples("johndoe@example.com"),
             PREFIX_ADDRESS.asOptional(),
             PREFIX_EDUCATION.asOptional(),
-            PREFIX_TELEGRAM.asOptional(),
+            PREFIX_TELEGRAM.asOptional().setExamples("@john_goh"),
             PREFIX_TAG.asOptional().asRepeatable(),
             PREFIX_MODULE.asOptional().asRepeatable()
     ));
@@ -63,10 +63,7 @@ public class EditCommand extends Command {
             + ARGUMENT_PREFIXES.stream()
                     .map(Prefix::toString)
                     .collect(Collectors.joining(" "))
-            + "\nExample: " + COMMAND_WORD + " 1 "
-            + PREFIX_PHONE + "91234567 "
-            + PREFIX_TELEGRAM + "@john_goh"
-            + PREFIX_EMAIL + "johndoe@example.com";
+            + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -13,7 +13,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.parser.Prefix;
@@ -40,11 +39,8 @@ public class FilterCommand extends Command {
     ));
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain ANY of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: \n"
-            + ARGUMENT_PREFIXES.stream()
-                    .map(Prefix::toString)
-                    .collect(Collectors.joining(" "))
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers."
+            + "\n" + getParameterUsage(ARGUMENT_PREFIXES)
             + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     private final ContainsKeywordsPredicate predicate;

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -28,14 +28,14 @@ public class FilterCommand extends Command {
 
     public static final String COMMAND_WORD = "filter";
     public static final ArrayList<Prefix> ARGUMENT_PREFIXES = new ArrayList<>(List.of(
-            PREFIX_NAME.asOptional().asRepeatable(),
+            PREFIX_NAME.asOptional().asRepeatable().setExamples("alice", "tan"),
             PREFIX_PHONE.asOptional().asRepeatable(),
             PREFIX_EMAIL.asOptional().asRepeatable(),
             PREFIX_ADDRESS.asOptional().asRepeatable(),
             PREFIX_EDUCATION.asOptional().asRepeatable(),
             PREFIX_TELEGRAM.asOptional().asRepeatable(),
             PREFIX_REMARK.asOptional().asRepeatable(),
-            PREFIX_TAG.asOptional().asRepeatable(),
+            PREFIX_TAG.asOptional().asRepeatable().setExamples("hasSubmitted"),
             PREFIX_MODULE.asOptional().asRepeatable()
     ));
 
@@ -45,7 +45,7 @@ public class FilterCommand extends Command {
             + ARGUMENT_PREFIXES.stream()
                     .map(Prefix::toString)
                     .collect(Collectors.joining(" "))
-            + "Example: " + COMMAND_WORD + " n/alice n/tan t/hasSubmitted";
+            + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     private final ContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -28,14 +28,14 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
     public static final ArrayList<Prefix> ARGUMENT_PREFIXES = new ArrayList<>(List.of(
-            PREFIX_NAME.asOptional().asRepeatable(),
+            PREFIX_NAME.asOptional().asRepeatable().setExamples("alice", "tan"),
             PREFIX_PHONE.asOptional().asRepeatable(),
             PREFIX_EMAIL.asOptional().asRepeatable(),
             PREFIX_ADDRESS.asOptional().asRepeatable(),
             PREFIX_EDUCATION.asOptional().asRepeatable(),
             PREFIX_TELEGRAM.asOptional().asRepeatable(),
             PREFIX_REMARK.asOptional().asRepeatable(),
-            PREFIX_TAG.asOptional().asRepeatable(),
+            PREFIX_TAG.asOptional().asRepeatable().setExamples("hasSubmitted"),
             PREFIX_MODULE.asOptional().asRepeatable()
     ));
 
@@ -45,7 +45,7 @@ public class FindCommand extends Command {
             + ARGUMENT_PREFIXES.stream()
                     .map(Prefix::toString)
                     .collect(Collectors.joining(" "))
-            + "\nExample: " + COMMAND_WORD + " n/alice n/tan t/hasSubmitted";
+            + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     private final FullMatchKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -13,7 +13,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.parser.Prefix;
@@ -40,11 +39,8 @@ public class FindCommand extends Command {
     ));
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain ALL of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: "
-            + ARGUMENT_PREFIXES.stream()
-                    .map(Prefix::toString)
-                    .collect(Collectors.joining(" "))
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers."
+            + "\n" + getParameterUsage(ARGUMENT_PREFIXES)
             + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     private final FullMatchKeywordsPredicate predicate;

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -25,8 +25,8 @@ public class RemarkCommand extends Command {
 
     public static final String COMMAND_WORD = "remark";
     public static final ArrayList<Prefix> ARGUMENT_PREFIXES = new ArrayList<>(List.of(
-            INDEX_PLACEHOLDER,
-            REMARK_PLACEHOLDER.asOptional()
+            INDEX_PLACEHOLDER.setExamples("1"),
+            REMARK_PLACEHOLDER.asOptional().setExamples("Likes to swim.")
     ));
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -37,7 +37,7 @@ public class RemarkCommand extends Command {
             + ARGUMENT_PREFIXES.stream()
                     .map(Prefix::toString)
                     .collect(Collectors.joining(" "))
-            + "\nExample: " + COMMAND_WORD + " 1 Likes to swim.";
+            + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Person: %1$s";
     public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Person: %1$s";

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -7,7 +7,6 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -32,11 +31,8 @@ public class RemarkCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the remark of the person identified "
             + "by the index number used in the last person listing. "
-            + "Existing remark will be overwritten by the input.\n"
-            + "Parameters: "
-            + ARGUMENT_PREFIXES.stream()
-                    .map(Prefix::toString)
-                    .collect(Collectors.joining(" "))
+            + "Existing remark will be overwritten by the input."
+            + "\n" + getParameterUsage(ARGUMENT_PREFIXES)
             + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Person: %1$s";

--- a/src/main/java/seedu/address/logic/commands/ShowRemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowRemarkCommand.java
@@ -23,14 +23,15 @@ public class ShowRemarkCommand extends Command {
 
     public static final String COMMAND_WORD = "show";
     public static final ArrayList<Prefix> ARGUMENT_PREFIXES = new ArrayList<>(List.of(
-            INDEX_PLACEHOLDER));
+            INDEX_PLACEHOLDER.setExamples("1")
+    ));
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the remarks added to a person.\n"
             + "Parameters: "
             + ARGUMENT_PREFIXES.stream()
                     .map(Prefix::toString)
                     .collect(Collectors.joining(" "))
-            + "\nExample: " + COMMAND_WORD + " 1";
+            + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     public static final String MESSAGE_SHOWN_REMARK_SUCCESS = "Remarks: %1$s";
     public static final String MESSAGE_SHOWN_REMARK_EMPTY = "No remarks yet...";

--- a/src/main/java/seedu/address/logic/commands/ShowRemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowRemarkCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.logic.parser.CliSyntax.INDEX_PLACEHOLDER;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -26,11 +25,8 @@ public class ShowRemarkCommand extends Command {
             INDEX_PLACEHOLDER.setExamples("1")
     ));
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the remarks added to a person.\n"
-            + "Parameters: "
-            + ARGUMENT_PREFIXES.stream()
-                    .map(Prefix::toString)
-                    .collect(Collectors.joining(" "))
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the remarks added to a person."
+            + "\n" + getParameterUsage(ARGUMENT_PREFIXES)
             + "\n" + getExampleUsage(COMMAND_WORD, ARGUMENT_PREFIXES);
 
     public static final String MESSAGE_SHOWN_REMARK_SUCCESS = "Remarks: %1$s";

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -19,25 +19,22 @@ public class Prefix {
     }
 
     /**
-     * Constructs a {@code Prefix} with given prefix and an no placeholder text.
-     * @param prefix Prefix value.
-     */
-    public Prefix(String prefix) {
-        this(prefix, "", false, false);
-    }
-
-    //@@author EvitanRelta-reused
-    // Reused from https://github.com/AY2223S1-CS2103T-T12-2/tp
-    // with minor modifications.
-    /**
      * Constructs a {@code Prefix} with given prefix and placeholder text.
      * @param prefix Prefix value.
      * @param placeholderText Placeholder text describing the expected data for the prefix.
      */
     public Prefix(String prefix, String placeholderText) {
+        //Solution below adapted from https://github.com/AY2223S1-CS2103T-T12-2/tp
         this(prefix, placeholderText, false, false);
     }
-    //@@author
+
+    /**
+     * Constructs a {@code Prefix} with given prefix and an no placeholder text.
+     * @param prefix Prefix value.
+     */
+    public Prefix(String prefix) {
+        this(prefix, "");
+    }
 
     /**
      * Returns true if this {@code Prefix} is just a placeholder for

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -1,5 +1,9 @@
 package seedu.address.logic.parser;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
  * A prefix that marks the beginning of an argument in an arguments string.
  * E.g. 't/' in 'add James t/ friend'.
@@ -9,13 +13,15 @@ public class Prefix {
     private final String placeholderText;
     private final boolean isOptionalPrefix;
     private final boolean isRepeatablePrefix;
+    private final List<String> examples;
 
     private Prefix(String prefix, String placeholderText, boolean isOptionalPrefix,
-            boolean isRepeatablePrefix) {
+            boolean isRepeatablePrefix, List<String> examples) {
         this.prefix = prefix;
         this.placeholderText = placeholderText;
         this.isOptionalPrefix = isOptionalPrefix;
         this.isRepeatablePrefix = isRepeatablePrefix;
+        this.examples = List.copyOf(examples);
     }
 
     /**
@@ -25,7 +31,7 @@ public class Prefix {
      */
     public Prefix(String prefix, String placeholderText) {
         //Solution below adapted from https://github.com/AY2223S1-CS2103T-T12-2/tp
-        this(prefix, placeholderText, false, false);
+        this(prefix, placeholderText, false, false, List.of());
     }
 
     /**
@@ -51,6 +57,11 @@ public class Prefix {
 
     public String getPrefix() {
         return prefix;
+    }
+
+    /** Returns the example values that this {@code Prefix} can take. */
+    public List<String> getExamples() {
+        return examples;
     }
 
     @Override
@@ -79,14 +90,36 @@ public class Prefix {
      * Returns a copy of this {@code Prefix}, but as an optional prefix.
      */
     public Prefix asOptional() {
-        return new Prefix(getPrefix(), getPlaceholderText(), true, isRepeatable());
+        return new Prefix(getPrefix(), getPlaceholderText(), true, isRepeatable(), getExamples());
     }
 
     /**
      * Returns a copy of this {@code Prefix}, but as an optional prefix.
      */
     public Prefix asRepeatable() {
-        return new Prefix(getPrefix(), getPlaceholderText(), isOptional(), true);
+        return new Prefix(getPrefix(), getPlaceholderText(), isOptional(), true, getExamples());
+    }
+
+    /**
+     * Returns a copy of this {@code Prefix}, but set the stored example values
+     * to {@code exampleValues}. The examples won't be accounted for in {@code Prefix::equals}.
+     * @param exampleValues Example values that the prefix can take.
+     */
+    public Prefix setExamples(List<String> exampleValues) {
+        return new Prefix(getPrefix(), getPlaceholderText(), isOptional(), isRepeatable(), exampleValues);
+    }
+
+    public Prefix setExamples(String... exampleValues) {
+        return this.setExamples(Arrays.asList(exampleValues));
+    }
+
+    /** Returns the example usage of this {@code Prefix}. */
+    public String toExampleString() {
+        return getExamples().isEmpty()
+            ? ""
+            : getExamples().stream()
+                    .map(example -> getPrefix() + example)
+                    .collect(Collectors.joining(" "));
     }
 
     @Override


### PR DESCRIPTION
Allow the `Prefix` class to hold example values to generate the command's `MESSAGE_USAGE` String, like:

![image](https://user-images.githubusercontent.com/35413456/230536502-f813e43d-635d-4ae2-abbc-a91a7b78304f.png)