### PR TITLE
Change thrown exceptions `AutocompleteEngine`

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -29,8 +29,9 @@ public interface Logic {
      * (ie. user input "ad" returns the suggestion "add ..." which includes the input "ad")
      * @param userInput The current user input.
      * @return An autocomplete suggestion.
+     * @throws ParseException If {@code userInput} likely has syntax errors (based on heuristics).
      */
-    String suggestCommand(String userInput) throws CommandException;
+    String suggestCommand(String userInput) throws ParseException;
 
     /**
      * Autocomplete a user input based on the current command suggestion.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -57,7 +57,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public String suggestCommand(String userInput) throws CommandException {
+    public String suggestCommand(String userInput) throws ParseException {
         return autocompleteEngine.suggestCommand(userInput);
     }
 

--- a/src/main/java/seedu/address/logic/commands/AutocompleteEngine.java
+++ b/src/main/java/seedu/address/logic/commands/AutocompleteEngine.java
@@ -112,7 +112,7 @@ public class AutocompleteEngine {
      *
      * @param userInput User input.
      * @return Suggested command (including the user input).
-     * @throws ParseException If the user input is invalid.
+     * @throws ParseException If {@code userInput} is likely invalid (based on heuristics).
      */
     public String suggestCommand(String userInput) throws ParseException {
         assert userInput != null : "'userInput' should not be 'null'";

--- a/src/main/java/seedu/address/logic/commands/AutocompleteEngine.java
+++ b/src/main/java/seedu/address/logic/commands/AutocompleteEngine.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.parser.CliSyntax.INDEX_PLACEHOLDER;
 import static seedu.address.logic.parser.CliSyntax.KEYWORD_PLACEHOLDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EDUCATION;
@@ -17,10 +19,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 
 //Solution below adapted from https://github.com/AY2223S1-CS2103T-T12-2/tp
@@ -110,9 +112,9 @@ public class AutocompleteEngine {
      *
      * @param userInput User input.
      * @return Suggested command (including the user input).
-     * @throws CommandException If the user input is invalid.
+     * @throws ParseException If the user input is invalid.
      */
-    public String suggestCommand(String userInput) throws CommandException {
+    public String suggestCommand(String userInput) throws ParseException {
         assert userInput != null : "'userInput' should not be 'null'";
 
         if (userInput.isBlank()) {
@@ -127,21 +129,20 @@ public class AutocompleteEngine {
         String commandWord = splitArr[0];
         String commandBody = splitArr.length > 1 ? " " + splitArr[1] : "";
 
-        CommandException noSuchCommandException = new CommandException(
-            String.format("No command starting with \"%s\" found.", commandWord));
+        ParseException unknownParseException = new ParseException(MESSAGE_UNKNOWN_COMMAND);
 
         boolean isCommandComplete = strippedLeadingInput.contains(" ");
         if (!isCommandComplete) {
             String suggestedCommand = COMMAND_LIST.stream()
                     .filter(command -> command.startsWith(commandWord))
                     .findFirst()
-                    .orElseThrow(() -> noSuchCommandException);
+                    .orElseThrow(() -> unknownParseException);
             return inputLeadingSpaces + suggestedCommand + suggestArguments(suggestedCommand, commandBody);
         }
 
         boolean isInvalidCommand = !COMMAND_LIST.contains(commandWord);
         if (isInvalidCommand) {
-            throw noSuchCommandException;
+            throw unknownParseException;
         }
 
         return userInput + suggestArguments(commandWord, commandBody);
@@ -183,9 +184,9 @@ public class AutocompleteEngine {
      * @param command The command to suggest arguments for.
      * @param commmandBody The command body of the current user input.
      * @return Suggested arguments.
-     * @throws CommandException If the user input is invalid.
+     * @throws ParseException If the user input is invalid.
      */
-    private String suggestArguments(String command, String commmandBody) throws CommandException {
+    private String suggestArguments(String command, String commmandBody) throws ParseException {
         ArrayList<Prefix> argPrefixes = ARGUMENT_PREFIX_MAP.get(command);
         assert argPrefixes != null;
         ArgumentMultimap argumentMultimap =
@@ -218,7 +219,7 @@ public class AutocompleteEngine {
                     .allMatch(word -> word.matches("\\d+"));
 
             if (!areAllValidIndexes) {
-                throw new CommandException("Invalid index.");
+                throw new ParseException(MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
         }
 
@@ -279,4 +280,5 @@ public class AutocompleteEngine {
                 .collect(Collectors.joining(" "));
         return remainingArgs;
     }
+
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -120,7 +120,7 @@ public class CommandBox extends UiPart<Region> {
          *
          * @see seedu.address.logic.Logic#suggestCommand(String)
          */
-        String suggest(String userInput) throws CommandException;
+        String suggest(String userInput) throws ParseException;
     }
 
     /**
@@ -169,7 +169,7 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandSuggestionTextField.setText(commandSuggestor.suggest(commandText));
             commandSuggestionTextField.positionCaret(commandTextField.getText().length());
-        } catch (CommandException e) {
+        } catch (ParseException e) {
             commandSuggestionTextField.setText(commandText);
             setStyleToIndicateCommandFailure();
         }


### PR DESCRIPTION
## The problem

1. `AutocompleteEngine::suggestCommand` currently throws `CommandException` despite not actually executing any commands _(which is what `CommandException` is for)_:<br>  
  ![image](https://user-images.githubusercontent.com/35413456/230717297-6adc2074-56ec-4ad0-85d5-5212e75c61f1.png)
2. Also, it should not throw custom error messages like `"No command starting with \"%s\" found."` or `""Invalid index.""`.  
   _(although those messages currently aren't actually displayed for the user)_

## The solution

1. It should instead be throwing `ParseException`.
2. It should instead be throwing already defined error messages:
   - `Messages.MESSAGE_UNKNOWN_COMMAND`
   - `Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX`